### PR TITLE
Render the site after merging a pull request

### DIFF
--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -6,7 +6,7 @@ name: Render website
 on:
   workflow_dispatch:
   push:
-    branches: [ main, staging ]
+    branches: [ main, gh-pages ]
     paths:
       - '**.Rmd'
 

--- a/.github/workflows/render-site.yml
+++ b/.github/workflows/render-site.yml
@@ -1,0 +1,38 @@
+
+# Candace Savonen Sept 2022
+
+name: Render website
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, staging ]
+    paths:
+      - '**.Rmd'
+
+jobs:
+  render-website:
+    name: Render website
+    runs-on: ubuntu-latest
+    container:
+      image: rocker/r-rmd
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Run site rendering
+      - name: Run bookdown render
+        id: bookdown
+        run: |
+          Rscript -e "rmarkdown::render_site()"
+
+      # Commit the rendered html files
+      - name: Commit rendered html files
+        run: |
+          git add --force *.html
+          git commit -m 'Render website' || echo "No changes to commit"
+          git pull --allow-unrelated-histories --strategy-option=ours
+          git push origin main || echo "No changes to push"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 Welcome to the Swirl Course Network. For more information please visit http://swirlstats.com/scn/.
+
+In order to add your course to the SCN:
+
+1. Create an .swc file for your course using the `swirlify::pack_course()` function. 
+2. Fork https://github.com/swirldev/scn on GitHub.
+3. Add the .swc file to your fork.
+4. Add an Rmd file to your fork like this one. You can include a description of your course, authors, a course website, and how to install your course.
+5. Add your course to the lists in both the `title.Rmd` and `surname.Rmd` files.
+6. Run `rmarkdown::render_site()` when your current directory is set to your fork.
+7. Add, commit, and push your changes to GitHub, then send us a Pull Request.
+8. After adding your course to the SCN students will be able to install your course using `install_course("[Name of Your Course]")` in swirl.


### PR DESCRIPTION
### Summary 

This PR adds a GitHub Action that runs `rmarkdown::render_site()` if changes to any Rmd files are committed to the gh-pages branch. 

Related to conversation here: https://github.com/swirldev/scn/pull/20#issuecomment-1260037825

Thought it would be nice to not have to worry about running this ourselves, and also have a docker image run these so that everything is rendered by the same operating system, package versions and etc. 

That way the Files Changed is much cleaner and we don't have to worry about whether things have been re-rendered properly. 