### PR TITLE
Fixing some DataTrail links

### DIFF
--- a/DataTrail_03_Cleaning_Data.Rmd
+++ b/DataTrail_03_Cleaning_Data.Rmd
@@ -27,7 +27,7 @@ swirl::install_course("DataTrail_03_Cleaning_Data")
 
 #### Manual Installation
 
-1. Download [this](http://swirlstats.com/scn/DataTrail_03_Cleaning_the_Data.swc) file.
+1. Download [this](http://swirlstats.com/scn/DataTrail_03_Cleaning_Data.swc) file.
 2. Run `swirl::install_course()` in the R console.
 3. Select the file you just downloaded.
 

--- a/DataTrail_04_Plotting_Data.Rmd
+++ b/DataTrail_04_Plotting_Data.Rmd
@@ -22,12 +22,12 @@ You can run through this section on the Leanpub course and get credit for this m
 ### Installation
 
 ```r
-swirl::install_course("DataTrail_04_Plot_the_Data")
+swirl::install_course("DataTrail_04_Plotting_Data")
 ```
 
 #### Manual Installation
 
-1. Download [this](http://swirlstats.com/scn/DataTrail_04_Plot_the_Data.swc) file.
+1. Download [this](http://swirlstats.com/scn/DataTrail_04_Plotting_Data.swc) file.
 2. Run `swirl::install_course()` in the R console.
 3. Select the file you just downloaded.
 

--- a/surname.Rmd
+++ b/surname.Rmd
@@ -25,10 +25,10 @@ output:
 - DataTrail team
     - [DataTrail - 01 Forming Questions](DataTrail_01_Forming_Questions.html)
     - [DataTrail - 02 Getting Data](DataTrail_02_Getting_Data.html)
-    - [DataTrail - 03 Cleaning the Data](DataTrail_03_Cleaning_the_Data.html)
-    - [DataTrail - 04 Plot the Data](DataTrail_04_Plot_the_Data.html)
-    - [DataTrail - 05 Get Stats](DataTrail_05_Get_Stats.html)
-    - [DataTrail - 06 Share Results](DataTrail_06_Share_Results.html)
+    - [DataTrail - 03 Cleaning Data](DataTrail_03_Cleaning_Data.html)
+    - [DataTrail - 04 Plotting Data](DataTrail_04_Plotting_Data.html)
+    - [DataTrail - 05 Getting Stats](DataTrail_05_Getting_Stats.html)
+    - [DataTrail - 06 Sharing Results](DataTrail_06_Sharing_Results.html)
 - David Duncan
     - [ConoceR](conocer.html)
 

--- a/title.Rmd
+++ b/title.Rmd
@@ -19,10 +19,10 @@ output:
 
 - [DataTrail - 01 Forming Questions](DataTrail_01_Forming_Questions.html)
 - [DataTrail - 02 Getting Data](DataTrail_02_Getting_Data.html)
-- [DataTrail - 03 Cleaning the Data](DataTrail_03_Cleaning_the_Data.html)
-- [DataTrail - 04 Plot the Data](DataTrail_04_Plot_the_Data.html)
-- [DataTrail - 05 Get Stats](DataTrail_05_Get_Stats.html)
-- [DataTrail - 06 Share Results](DataTrail_06_Share_Results.html)
+- [DataTrail - 03 Cleaning Data](DataTrail_03_Cleaning_Data.html)
+- [DataTrail - 04 Plotting Data](DataTrail_04_Plotting_Data.html)
+- [DataTrail - 05 Getting Stats](DataTrail_05_Getting_Stats.html)
+- [DataTrail - 06 Sharing Results](DataTrail_06_Sharing_Results.html)
 - [Data Science and R](dsandr.html) by Wush Wu
 - [Daten einlesen und kennenlernen](Daten_einlesen_und_kennenlernen.html) by RLab-Team
 - [Daten visualisieren mit ggplot2](Daten_visualisieren_mit_ggplot2.html) by RLab-Team


### PR DESCRIPTION
Some of the DataTrail instructions are wrong here because at some point we updated the module names like for example "Cleaning_the_Data" module to be just called "Cleaning_Data". But I hadn't caught all the places this needed to be changed. 

This caused issues for one of the participants so I'm trying to update it!